### PR TITLE
feat: use pipeline UI with i18n.  Update profile controller

### DIFF
--- a/kustomize/application/pipeline/deployment.yaml
+++ b/kustomize/application/pipeline/deployment.yaml
@@ -18,3 +18,5 @@ spec:
           value: mlpipeline
         - name: ARGO_ARCHIVE_PREFIX
           value: artifacts
+        # TODO: Map this to a variable somewhere?
+        image: k8scc01covidacr.azurecr.io/kubeflow-pipeline/kubeflow-pipeline:5c41c42f

--- a/kustomize/application/pipeline/kubeflow-pipelines-profile-controller-env.yaml
+++ b/kustomize/application/pipeline/kubeflow-pipelines-profile-controller-env.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: 
+  name: kubeflow-pipelines-profile-controller-env
+data:
+  VISUALIZATION_SERVER_IMAGE: "k8scc01covidacr.azurecr.io/kubeflow-pipeline/kubeflow-pipeline"
+  FRONTEND_IMAGE: "k8scc01covidacr.azurecr.io/kubeflow-pipeline/kubeflow-pipeline"
+  VISUALIZATION_SERVER_TAG: "5c41c42f"
+  FRONTEND_TAG: "5c41c42f"

--- a/kustomize/application/pipeline/kustomization.yaml
+++ b/kustomize/application/pipeline/kustomization.yaml
@@ -3,5 +3,11 @@ kind: Kustomization
 patchesStrategicMerge:
 - deployment.yaml
 - service.yaml
+- kubeflow-pipelines-profile-controller-env.yaml
+configMapGenerator:
+- name: kubeflow-pipelines-profile-controller-code
+  files:
+  - sync.py
+  behavior: replace
 resources:
-- ../../../.cache/manifests/manifests-1.2-branch/pipeline/installs/multi-user
+- ../../../.cache/manifests/manifests-1.2-branch/pipeline/installs/multi-user/

--- a/kustomize/application/pipeline/requirements-dev.txt
+++ b/kustomize/application/pipeline/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-lazy-fixture

--- a/kustomize/application/pipeline/requirements-dev.txt
+++ b/kustomize/application/pipeline/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-lazy-fixture
+requests

--- a/kustomize/application/pipeline/sync.py
+++ b/kustomize/application/pipeline/sync.py
@@ -1,0 +1,386 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import os
+import base64
+from functools import partial
+
+
+
+class Controller(BaseHTTPRequestHandler):
+    def __init__(self, *args, visualization_server_image=None,
+        visualization_server_tag=None, frontend_image=None, frontend_tag=None,
+        disable_istio_sidecar=None, mlpipeline_minio_access_key=None,
+        mlpipeline_minio_secret_key=None, **kwargs):
+        """
+        Executes a controller syncronization event using an incoming post
+
+        Note that because HTTPServer instantiates a new Handler instance for
+        each post at time of receipt (rather than invoking the same Handler
+        instance for each post) and because HTTPServer has no interface for
+        passing extra data at Handler instantiation (such as frontend_image),
+        this Controller is typically prepared for usage with functools.partial.
+        An example of this is available at
+        Controller.partial_init_from_environment().
+
+        Args:
+            visualization_server_image (str): repo/imagename for the ml-pipeline-visualizationserver deployment
+            visualization_server_tag (str): tag for the ml-pipeline-visualizationserver deployment
+            frontend_image (str):  repo/imagename for the ml-pipeline-ui-artifact deployment
+            frontend_tag (str): tag for the ml-pipeline-ui-artifact deployment
+            disable_istio_sidecar (str): "true" or "false"
+            mlpipeline_minio_access_key (str): access_key for pipelines minio store
+            mlpipeline_minio_secret_key (str): secret_key for pipelines minio store
+
+        Returns:
+            None
+        """
+        self.visualization_server_image = visualization_server_image
+        self.frontend_image = frontend_image
+        self.visualization_server_tag = visualization_server_tag
+        self.frontend_tag = frontend_tag
+        self.disable_istio_sidecar = disable_istio_sidecar
+        self.mlpipeline_minio_access_key = mlpipeline_minio_access_key
+        self.mlpipeline_minio_secret_key = mlpipeline_minio_secret_key
+
+        super().__init__(*args, **kwargs)
+
+    def sync(self, parent, children):
+        # HACK: Currently using serving.kubeflow.org/inferenceservice to identify
+        # kubeflow user namespaces.
+        # TODO: let Kubeflow profile controller add a pipeline specific label to
+        # user namespaces and use that label instead.
+        pipeline_enabled = parent.get("metadata", {}).get(
+            "labels", {}).get("serving.kubeflow.org/inferenceservice")
+
+        if not pipeline_enabled:
+            return {"status": {}, "children": []}
+
+        # Compute status based on observed state.
+        desired_status = {
+            "kubeflow-pipelines-ready": \
+                len(children["Secret.v1"]) == 1 and \
+                len(children["ConfigMap.v1"]) == 1 and \
+                len(children["Deployment.apps/v1"]) == 2 and \
+                len(children["Service.v1"]) == 2 and \
+                len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and \
+                len(children["ServiceRole.rbac.istio.io/v1alpha1"]) == 1 and \
+                len(children["ServiceRoleBinding.rbac.istio.io/v1alpha1"]) == 1 and \
+                "True" or "False"
+        }
+
+        # Generate the desired child object(s).
+        # parent is a namespace
+        namespace = parent.get("metadata", {}).get("name")
+        desired_resources = [
+            {
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "metadata-grpc-configmap",
+                    "namespace": namespace,
+                },
+                "data": {
+                    "METADATA_GRPC_SERVICE_HOST":
+                    "metadata-grpc-service.kubeflow",
+                    "METADATA_GRPC_SERVICE_PORT": "8080",
+                },
+            },
+            # Visualization server related manifests below
+            {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                    "labels": {
+                        "app": "ml-pipeline-visualizationserver"
+                    },
+                    "name": "ml-pipeline-visualizationserver",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "selector": {
+                        "matchLabels": {
+                            "app": "ml-pipeline-visualizationserver"
+                        },
+                    },
+                    "template": {
+                        "metadata": {
+                            "labels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            },
+                            "annotations": self.disable_istio_sidecar and {
+                                "sidecar.istio.io/inject": "false"
+                            } or {},
+                        },
+                        "spec": {
+                            "containers": [{
+                                "image": f"{self.visualization_server_image}:{self.visualization_server_tag}",
+                                "imagePullPolicy":
+                                "IfNotPresent",
+                                "name":
+                                "ml-pipeline-visualizationserver",
+                                "ports": [{
+                                    "containerPort": 8888
+                                }],
+                            }],
+                            "serviceAccountName":
+                            "default-editor",
+                        },
+                    },
+                },
+            },
+            {
+                "apiVersion": "networking.istio.io/v1alpha3",
+                "kind": "DestinationRule",
+                "metadata": {
+                    "name": "ml-pipeline-visualizationserver",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "host": "ml-pipeline-visualizationserver",
+                    "trafficPolicy": {
+                        "tls": {
+                            "mode": "ISTIO_MUTUAL"
+                        }
+                    }
+                }
+            },
+            {
+                "apiVersion": "rbac.istio.io/v1alpha1",
+                "kind": "ServiceRole",
+                "metadata": {
+                    "name": "ml-pipeline-visualizationserver",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "rules": [{
+                        "services": ["ml-pipeline-visualizationserver.*"]
+                    }]
+                }
+            },
+            {
+                "apiVersion": "rbac.istio.io/v1alpha1",
+                "kind": "ServiceRoleBinding",
+                "metadata": {
+                    "name": "ml-pipeline-visualizationserver",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "subjects": [{
+                        "properties": {
+                            "source.principal":
+                            "cluster.local/ns/kubeflow/sa/ml-pipeline"
+                        }
+                    }],
+                    "roleRef": {
+                        "kind": "ServiceRole",
+                        "name": "ml-pipeline-visualizationserver"
+                    }
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "name": "ml-pipeline-visualizationserver",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "ports": [{
+                        "name": "http",
+                        "port": 8888,
+                        "protocol": "TCP",
+                        "targetPort": 8888,
+                    }],
+                    "selector": {
+                        "app": "ml-pipeline-visualizationserver",
+                    },
+                },
+            },
+            # Artifact fetcher related resources below.
+            {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                    "labels": {
+                        "app": "ml-pipeline-ui-artifact"
+                    },
+                    "name": "ml-pipeline-ui-artifact",
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "selector": {
+                        "matchLabels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    },
+                    "template": {
+                        "metadata": {
+                            "labels": {
+                                "app": "ml-pipeline-ui-artifact"
+                            },
+                            "annotations": self.disable_istio_sidecar and {
+                                "sidecar.istio.io/inject": "false"
+                            } or {},
+                        },
+                        "spec": {
+                            "containers": [{
+                                "name":
+                                "ml-pipeline-ui-artifact",
+                                "image": f"{self.frontend_image}:{self.frontend_tag}",
+                                "imagePullPolicy":
+                                "IfNotPresent",
+                                "ports": [{
+                                    "containerPort": 3000
+                                }]
+                            }],
+                            "serviceAccountName":
+                            "default-editor"
+                        }
+                    }
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "name": "ml-pipeline-ui-artifact",
+                    "namespace": namespace,
+                    "labels": {
+                        "app": "ml-pipeline-ui-artifact"
+                    }
+                },
+                "spec": {
+                    "ports": [{
+                        "name":
+                        "http",  # name is required to let istio understand request protocol
+                        "port": 80,
+                        "protocol": "TCP",
+                        "targetPort": 3000
+                    }],
+                    "selector": {
+                        "app": "ml-pipeline-ui-artifact"
+                    }
+                }
+            },
+        ]
+        # print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
+        # print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))
+        # Moved after the print argument because this is sensitive data.
+        desired_resources.append({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": "mlpipeline-minio-artifact",
+                "namespace": namespace,
+            },
+            "data": {
+                "accesskey": self.mlpipeline_minio_access_key,
+                "secretkey": self.mlpipeline_minio_secret_key,
+            },
+        })
+
+        return {"status": desired_status, "children": desired_resources}
+
+    def do_POST(self):
+        # Serve the sync() function as a JSON webhook.
+        observed = json.loads(
+            self.rfile.read(int(self.headers.get("content-length"))))
+        desired = self.sync(observed["parent"], observed["children"])
+
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+
+    @staticmethod
+    def get_settings_from_environment(visualization_server_image=None, frontend_image=None,
+            visualization_server_tag=None, frontend_tag=None, disable_istio_sidecar=None,
+            mlpipeline_minio_access_key=None, mlpipeline_minio_secret_key=None):
+        """
+        Returns a dict of settings from environment variables relevant to the controller
+
+        Environment settings can be overridden by passing them here as arguments.
+
+        Settings are pulled from the all-caps version of the setting name.  The
+        following defaults are used if those environment variables are not set
+        to enable backwards compatability with previous versions of this script:
+            visualization_server_image: gcr.io/ml-pipeline/visualization-server
+            visualization_server_tag: value of KFP_VERSION environment variable
+            frontend_image: gcr.io/ml-pipeline/frontend
+            frontend_tag: value of KFP_VERSION environment variable
+            disable_istio_sidecar: Required (no default)
+            mlpipeline_minio_access_key: Required (no default)
+            mlpipeline_minio_secret_key: Required (no default)
+        """
+        settings = {}
+        settings["visualization_server_image"] = \
+            visualization_server_image or \
+            os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+
+        settings["frontend_image"] = \
+            frontend_image or \
+            os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+
+        # Look for specific tags for each image first, falling back to
+        # previously used KFP_VERSION environment variable for backwards
+        # compatibility
+        settings["visualization_server_tag"] = \
+            visualization_server_image or \
+            os.environ.get("VISUALIZATION_SERVER_TAG") or \
+            os.environ["KFP_VERSION"]
+
+        settings["frontend_tag"] = \
+            visualization_server_image or \
+            os.environ.get("FRONTEND_TAG") or \
+            os.environ["KFP_VERSION"]
+
+        settings["disable_istio_sidecar"] = \
+            disable_istio_sidecar if disable_istio_sidecar is not None \
+            else os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+
+        settings["mlpipeline_minio_access_key"] = \
+            mlpipeline_minio_access_key or \
+            base64.b64encode(bytes(os.environ.get("MINIO_ACCESS_KEY"), 'utf-8')).decode('utf-8')
+
+        settings["mlpipeline_minio_secret_key"] = \
+            mlpipeline_minio_access_key or \
+            base64.b64encode(bytes(os.environ.get("MINIO_SECRET_KEY"), 'utf-8')).decode('utf-8')
+
+        return settings
+
+    @classmethod
+    def partial_init_from_environment(cls):
+        """
+        Returns this class partially instantiated with settings inferred from environment variables
+
+        Useful for building a version of this Controller that can be consumed by
+        HTTPServer as a handler, but that includes all settings inferred from
+        environment variables, an a testable way.
+        """
+        settings = cls.get_settings_from_environment()
+        return partial(cls, **settings)
+
+
+def serve_controller_forever(port=80):
+    controller_partial = Controller.partial_init_from_environment()
+    server = HTTPServer(("", port), Controller)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("CONTROLLER_PORT", "80"))
+    serve_controller_forever(port)

--- a/kustomize/application/pipeline/test_sync.py
+++ b/kustomize/application/pipeline/test_sync.py
@@ -2,7 +2,7 @@ import os
 from unittest import mock
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from sync_modified import Controller
+from sync import Controller
 import json
 import time 
 

--- a/kustomize/application/pipeline/test_sync.py
+++ b/kustomize/application/pipeline/test_sync.py
@@ -1,0 +1,215 @@
+import os
+from unittest import mock
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from sync_modified import Controller
+import json
+import time 
+
+import pytest
+import requests
+
+# Misc Constants
+SERVER_ADDRESS = ("", 0)  # resolves to localhost:some_free_port
+
+# Data sets passed to server
+DATA_INCORRECT_CHILDREN = {
+    "parent": {
+        "metadata": {
+            "labels": {
+                "serving.kubeflow.org/inferenceservice": "true"
+            },
+            "name": "myName"
+        }
+    },
+    "children": {
+        "Secret.v1": [],
+        "ConfigMap.v1": [],
+        "Deployment.apps/v1": [],
+        "Service.v1": [],
+        "DestinationRule.networking.istio.io/v1alpha3": [],
+        "ServiceRole.rbac.istio.io/v1alpha1": [],
+        "ServiceRoleBinding.rbac.istio.io/v1alpha1": []
+    }
+}
+
+DATA_CORRECT_CHILDREN = {
+    "parent": {
+        "metadata": {
+            "labels": {
+                "serving.kubeflow.org/inferenceservice": "true"
+            },
+            "name": "myName"
+        }
+    },
+    "children": {
+        "Secret.v1": [1],
+        "ConfigMap.v1": [1],
+        "Deployment.apps/v1": [1, 1],
+        "Service.v1": [1, 1],
+        "DestinationRule.networking.istio.io/v1alpha3": [1],
+        "ServiceRole.rbac.istio.io/v1alpha1": [1],
+        "ServiceRoleBinding.rbac.istio.io/v1alpha1": [1]
+    }
+}
+
+DATA_MISSING_INFERENCESERVICE = {"parent": {}, "children": {}}
+
+# Default values when environments are not explicit
+DEFAULT_FRONTEND_IMAGE="gcr.io/ml-pipeline/frontend"
+DEFAULT_VISUALIZATION_IMAGE="gcr.io/ml-pipeline/visualization-server"
+
+# Variables used for environment variable sets
+VISUALIZATION_SERVER_IMAGE="vis-image"
+VISUALIZATION_SERVER_TAG="somenumber.1.2.3"
+FRONTEND_IMAGE="frontend-image"
+FRONTEND_TAG="somehash"
+
+KFP_VERSION="x.y.z"
+
+MINIO_ACCESS_KEY="abcdef"
+MINIO_SECRET_KEY="uvwxyz"
+
+# "Environments" used in tests
+ENV_VARIABLES_BASE = {
+    "MINIO_ACCESS_KEY": MINIO_ACCESS_KEY,
+    "MINIO_SECRET_KEY": MINIO_SECRET_KEY,
+}
+
+ENV_KFP_VERSION_ONLY = dict(ENV_VARIABLES_BASE, 
+    **{
+        "KFP_VERSION": KFP_VERSION,
+    }
+)
+
+ENV_IMAGES_NO_TAGS = dict(ENV_VARIABLES_BASE, 
+    **{
+        "KFP_VERSION": KFP_VERSION,
+        "VISUALIZATION_SERVER_IMAGE": VISUALIZATION_SERVER_IMAGE,
+        "FRONTEND_IMAGE": FRONTEND_IMAGE,
+    }
+)
+
+ENV_IMAGES_WITH_TAGS = dict(ENV_VARIABLES_BASE, 
+    **{
+    "VISUALIZATION_SERVER_IMAGE": VISUALIZATION_SERVER_IMAGE,
+    "FRONTEND_IMAGE": FRONTEND_IMAGE,
+    "VISUALIZATION_SERVER_TAG": VISUALIZATION_SERVER_TAG,
+    "FRONTEND_TAG": FRONTEND_TAG,
+    }
+)
+
+
+def generate_image_name(imagename, tag):
+    return f"{str(imagename)}:{str(tag)}"
+
+
+@pytest.fixture(
+    scope="function",
+)
+def sync_server(request):
+    """
+    Starts the sync HTTP server for a given set of environment variables on a separate thread
+
+    Yields:
+    * the server (useful to interrogate for the server address)
+    * environment variables (useful to interrogate for correct responses)
+    """
+    environ = request.param
+    with mock.patch.dict(os.environ, environ):
+        # Create a server at an available port and serve it on a thread as a daemon
+        # This will result in a collection of servers being active - not a great way
+        # if this fixture is run many times during a test, but ok for now
+        handler_partial = Controller.partial_init_from_environment()
+        server = HTTPServer(SERVER_ADDRESS, handler_partial)
+        server_thread = threading.Thread(target=server.serve_forever)
+        # Put on daemon so it doesn't keep pytest from ending
+        server_thread.daemon = True
+        server_thread.start()
+        yield server, environ
+
+
+@pytest.mark.parametrize(
+    "sync_server, data, expected_status, expected_visualization_server_image, expected_frontend_server_image",
+    [
+        (
+            ENV_KFP_VERSION_ONLY, 
+            DATA_INCORRECT_CHILDREN, 
+            {"kubeflow-pipelines-ready": "False"},
+            generate_image_name(DEFAULT_VISUALIZATION_IMAGE, KFP_VERSION),
+            generate_image_name(DEFAULT_FRONTEND_IMAGE, KFP_VERSION),
+        ),
+        (
+            ENV_IMAGES_NO_TAGS,
+            DATA_INCORRECT_CHILDREN,
+            {"kubeflow-pipelines-ready": "False"},
+            generate_image_name(ENV_IMAGES_NO_TAGS["VISUALIZATION_SERVER_IMAGE"], KFP_VERSION),
+            generate_image_name(ENV_IMAGES_NO_TAGS["FRONTEND_IMAGE"], KFP_VERSION),
+        ),
+        (
+            ENV_IMAGES_WITH_TAGS,
+            DATA_INCORRECT_CHILDREN,
+            {"kubeflow-pipelines-ready": "False"},
+            generate_image_name(ENV_IMAGES_WITH_TAGS["VISUALIZATION_SERVER_IMAGE"], ENV_IMAGES_WITH_TAGS["VISUALIZATION_SERVER_TAG"]),
+            generate_image_name(ENV_IMAGES_WITH_TAGS["FRONTEND_IMAGE"], ENV_IMAGES_WITH_TAGS["FRONTEND_TAG"]),
+        ),
+        (
+            ENV_IMAGES_WITH_TAGS,
+            DATA_CORRECT_CHILDREN,
+            {"kubeflow-pipelines-ready": "True"},
+            generate_image_name(ENV_IMAGES_WITH_TAGS["VISUALIZATION_SERVER_IMAGE"], ENV_IMAGES_WITH_TAGS["VISUALIZATION_SERVER_TAG"]),
+            generate_image_name(ENV_IMAGES_WITH_TAGS["FRONTEND_IMAGE"], ENV_IMAGES_WITH_TAGS["FRONTEND_TAG"]),
+        ),
+    ],
+    indirect=["sync_server"]
+)
+def test_sync_server_with_inferenceservice(sync_server, data, expected_status, 
+    expected_visualization_server_image, expected_frontend_server_image):
+    """
+    Nearly end-to-end test of how Controller serves .sync as a POST
+
+    Tests case where metadata.labels.serving.kubeflow.org/inferenceservice exists, and thus
+    we should produce children
+
+    Only does spot checks on children to see if key properties are correct
+    """
+    server, environ = sync_server
+
+    # server.server_address = (url, port_as_integer)
+    url = f"http://{server.server_address[0]}:{str(server.server_address[1])}"
+    x = requests.post(url, data=json.dumps(data))
+    results = json.loads(x.text)
+
+    # Test overall status of whether children are ok
+    assert results['status'] == expected_status
+
+    # Poke a few children to test things that can vary by environment variable
+    assert results['children'][1]["spec"]["template"]["spec"]["containers"][0]["image"] == expected_visualization_server_image
+    assert results['children'][6]["spec"]["template"]["spec"]["containers"][0]["image"] == expected_frontend_server_image
+
+
+@pytest.mark.parametrize(
+    "sync_server, data, expected_status, expected_children",
+    [
+        (ENV_IMAGES_WITH_TAGS, DATA_MISSING_INFERENCESERVICE, {}, []),
+    ],
+    indirect=["sync_server"]
+)
+def test_sync_server_without_inferenceservice(sync_server, data, expected_status, 
+    expected_children):
+    """
+    Nearly end-to-end test of how Controller serves .sync as a POST
+
+    Tests case where metadata.labels.serving.kubeflow.org/inferenceservice does not 
+    exist and thus server returns an empty reply
+    """
+    server, environ = sync_server
+
+    # server.server_address = (url, port_as_integer)
+    url = f"http://{server.server_address[0]}:{str(server.server_address[1])}"
+    x = requests.post(url, data=json.dumps(data))
+    results = json.loads(x.text)
+
+    # Test overall status of whether children are ok
+    assert results['status'] == expected_status
+    assert results['children'] == expected_children


### PR DESCRIPTION
co-authored with @Nancy-Badran. Resolves #99 

This is to deploy a custom pipeline ui image.  Kubeflow uses this image in three places:
* The `ml-pipeline-ui` deployment, which is a global deployment across the entire kubeflow instance
* The `ml-pipeline-visualizationserver` and `ml-pipeline-ui-artifact` deployments, which are both deployed in each user's namespace and managed by the `kubeflow-pipelines-profile-controller`

This PR:
* Updates the `kubeflow-pipelines-profile-controller` (specifically `sync.py`) to expose custom image specifications as environment variables, as well as to add a test suite.  Details of changes to the kubeflow-pipelines-profile-controller are outlined in kubeflow/pipelines#5732, which was opened to upstream the new controller.
* Adds environment variables via a configmap to specify the custom images for the `kubeflow-pipelines-profile-controller`
* Adds a custom image to `ml-pipeline-ui` deployment

Todo:
* [ ] The image to deploy and the `sync.py` controller have both been tested in isolation, but before merging this we should probably test this in the dev cluster?