### PR TITLE
feat(centraldashboard): add pipeline items to left menu as top-level items

### DIFF
--- a/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
+++ b/kustomize/apps/centraldashboard/base/centraldashboard-config.yaml
@@ -1,136 +1,208 @@
 apiVersion: v1
+data:
+  defaultLanguage: "en"
+  settings: |-
+    {
+      DASHBOARD_FORCE_IFRAME: true
+    }
+  links: |-
+    {
+     "en":
+      { 
+        "menuLinks": [
+        {
+          "type": "item",
+          "link": "/jupyter/",
+          "text": "Notebooks",
+          "icon": "book"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/",
+          "text": "Pipelines",
+          "icon": "kubeflow:pipeline-centered"
+        },
+        {
+          "type": "item",
+          "text": "Experiments (KFP)",
+          "link": "/pipeline/#/experiments",
+          "icon": "done-all"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Runs",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Recurring Runs",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artifacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Executions",
+          "icon": "av:play-arrow"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib",
+          "icon": "kubeflow:katib"
+        }
+      ],
+     "externalLinks": [],
+     "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Studies",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+       ],
+      "documentationItems": [
+        {
+          "text": "Advanced Analytics Workspace Docs",
+          "desc": "Helpful guides about our data and analysis tools",
+          "link": "https://statcan.github.io/daaas/"
+        },
+        {
+          "text": "Video Tutorial Series",
+          "desc": "YouTube playlist of videos for getting started with Advanced Analytics Workspace tools",
+          "link": "https://www.youtube.com/playlist?list=PL1zlA2D7AHugkDdiyeUHWOKGKUd3MB_nD"
+        },
+        {
+          "text": "Community Chat",
+          "desc": "Slack workspace for discussion/support - requires sign-up for emails outside @canada.ca",
+          "link": "https://statcan-aaw.slack.com/"
+        },
+        {
+          "text": "Official Kubeflow Docs",
+          "desc": "Advanced documentation for installing, running, and using Kubeflow",
+          "link": "https://www.kubeflow.org/docs/"
+        }
+       ]
+     },
+     "fr":
+      {
+        "menuLinks": [
+        {
+          "type": "item",
+          "link": "/jupyter/",
+          "text": "Serveur Bloc-notes",
+          "icon": "book"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/",
+          "text": "Pipelines",
+          "icon": "kubeflow:pipeline-centered"
+        },
+        {
+          "type": "item",
+          "text": "Expériences (KFP)",
+          "link": "/pipeline/#/experiments",
+          "icon": "done-all"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Exécutions",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Exécutions récurrentes",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artefacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Exécutions en cours",
+          "icon": "av:play-arrow"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib",
+          "icon": "kubeflow:katib"
+        }
+       ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Télécharger un pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "Voir tous les pipelines exécutés",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Créer un nouveau serveur bloc-notes",
+          "desc": "Serveur bloc-notes",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "Voir Katib Studies",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+       ],
+      "documentationItems": [
+        {
+          "text": "Documents de l'espace d'analyses avancées",
+          "desc": "Guides utiles pour nos données et outils d'analyse",
+          "link": "https://statcan.github.io/daaas/"
+        },
+        {
+          "text": "Série de didacticiels vidéos",
+          "desc": "Playlist de vidéos YouTube pour commencer avec les outils de l'espace d'analyses avancées",
+          "link": "https://www.youtube.com/playlist?list=PL1zlA2D7AHugkDdiyeUHWOKGKUd3MB_nD"
+        },
+        {
+          "text": "Clavardage de la communauté",
+          "desc": "Espace de travail Slack pour discussion/support - besoin de s'inscrire pour les courriels en dehors de @canada.ca",
+          "link": "https://statcan-aaw.slack.com/"
+        },
+        {
+          "text": "Documents Kubeflow Officiels",
+          "desc": "Documentation avancé pour installer, exécuter et utiliser Kubeflow",
+          "link": "https://www.kubeflow.org/docs/"
+        }
+       ]
+     }
+    }
 kind: ConfigMap
 metadata:
   name: centraldashboard-config
   namespace: kubeflow
-data:
-  defaultLanguage: "en"
-  links: |-
-    {
-      "en": {
-        "menuLinks": [
-          {
-            "link": "/pipeline/",
-            "text": "Pipelines"
-          },
-          {
-            "link": "/jupyter/",
-            "text": "Notebook Servers"
-          },
-          {
-            "link": "/katib/",
-            "text": "Katib"
-          }
-        ],
-        "externalLinks": [],
-        "quickLinks": [
-          {
-            "text": "Upload a pipeline",
-            "desc": "Pipelines",
-            "link": "/pipeline/"
-          },
-          {
-            "text": "View all pipeline runs",
-            "desc": "Pipelines",
-            "link": "/pipeline/#/runs"
-          },
-          {
-            "text": "Create a new Notebook server",
-            "desc": "Notebook Servers",
-            "link": "/jupyter/new?namespace=kubeflow"
-          },
-          {
-            "text": "View Katib Studies",
-            "desc": "Katib",
-            "link": "/katib/"
-          }
-        ],
-        "documentationItems": [
-          {
-            "text": "Advanced Analytics Workspace Docs",
-            "desc": "Helpful guides about our data and analysis tools",
-            "link": "https://statcan.github.io/daaas/"
-          },
-          {
-            "text": "Video Tutorial Series",
-            "desc": "YouTube playlist of videos for getting started with Advanced Analytics Workspace tools",
-            "link": "https://www.youtube.com/playlist?list=PL1zlA2D7AHugkDdiyeUHWOKGKUd3MB_nD"
-          },
-          {
-            "text": "Community Chat",
-            "desc": "Slack workspace for discussion/support - requires sign-up for emails outside @canada.ca",
-            "link": "https://statcan-aaw.slack.com/"
-          },
-          {
-            "text": "Official Kubeflow Docs",
-            "desc": "Advanced documentation for installing, running, and using Kubeflow",
-            "link": "https://www.kubeflow.org/docs/"
-          }
-        ]
-      },
-      "fr": {
-        "menuLinks": [
-          {
-            "link": "/pipeline/",
-            "text": "Pipelines"
-          },
-          {
-            "link": "/jupyter/",
-            "text": "Serveur Bloc-notes"
-          },
-          {
-            "link": "/katib/",
-            "text": "Katib"
-          }
-        ],
-        "externalLinks": [],
-        "quickLinks": [
-          {
-            "text": "Télécharger un pipeline",
-            "desc": "Pipelines",
-            "link": "/pipeline/"
-          },
-          {
-            "text": "Voir tous les pipelines exécutés",
-            "desc": "Pipelines",
-            "link": "/pipeline/#/runs"
-          },
-          {
-            "text": "Créer un nouveau serveur bloc-notes",
-            "desc": "Serveur bloc-notes",
-            "link": "/jupyter/new?namespace=kubeflow"
-          },
-          {
-            "text": "Voir Katib Studies",
-            "desc": "Katib",
-            "link": "/katib/"
-          }
-        ],
-        "documentationItems": [
-          {
-            "text": "Documents de l'espace d'analyses avancées",
-            "desc": "Guides utiles pour nos données et outils d'analyse",
-            "link": "https://statcan.github.io/daaas/"
-          },
-          {
-            "text": "Série de didacticiels vidéos",
-            "desc": "Playlist de vidéos YouTube pour commencer avec les outils de l'espace d'analyses avancées",
-            "link": "https://www.youtube.com/playlist?list=PL1zlA2D7AHugkDdiyeUHWOKGKUd3MB_nD"
-          },
-          {
-            "text": "Clavardage de la communauté",
-            "desc": "Espace de travail Slack pour discussion/support - besoin de s'inscrire pour les courriels en dehors de @canada.ca",
-            "link": "https://statcan-aaw.slack.com/"
-          },
-          {
-            "text": "Documents Kubeflow Officiels",
-            "desc": "Documentation avancé pour installer, exécuter et utiliser Kubeflow",
-            "link": "https://www.kubeflow.org/docs/"
-          }
-        ]
-      }
-    }
-  settings: |-
-    {
-      "DASHBOARD_FORCE_IFRAME": true
-    }


### PR DESCRIPTION
With upgrade to KF 1.3, Pipelines no longer has it's own side menu. This PR adds those items to the main left menu as top-level items.

Closes [#838](https://github.com/StatCan/daaas/issues/838)

cc @rohank07 